### PR TITLE
[Code Style] Enforce code style with .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,274 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+
+[*.yml]
+indent_size = 2
+
+[*.{csproj,ilproj,props,targets}]
+indent_size = 2
+
+[*.{cs,vb}]
+indent_style = space
+indent_size = 2
+
+# https://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_indent_block_contents
+csharp_indent_block_contents = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_indent_braces
+csharp_indent_braces = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_indent_case_contents
+csharp_indent_case_contents = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_indent_labels
+csharp_indent_labels = one_less_than_current
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_indent_switch_labels
+csharp_indent_switch_labels = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_before_catch
+csharp_new_line_before_catch = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_before_else
+csharp_new_line_before_else = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_before_finally
+csharp_new_line_before_finally = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_before_members_in_anonymous_types
+csharp_new_line_before_members_in_anonymous_types = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_before_members_in_object_initializers
+csharp_new_line_before_members_in_object_initializers = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_before_open_brace
+csharp_new_line_before_open_brace = all
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_new_line_between_query_expression_clauses
+csharp_new_line_between_query_expression_clauses = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_prefer_braces
+# csharp_prefer_braces = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_prefer_simple_default_expression
+csharp_prefer_simple_default_expression = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_preserve_single_line_blocks
+csharp_preserve_single_line_blocks = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_preserve_single_line_statements
+csharp_preserve_single_line_statements = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_cast
+csharp_space_after_cast = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_colon_in_inheritance_clause
+csharp_space_after_colon_in_inheritance_clause = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_comma
+csharp_space_after_comma = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_dot
+csharp_space_after_dot = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_keywords_in_control_flow_statements
+csharp_space_after_keywords_in_control_flow_statements = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_semicolon_in_for_statement
+csharp_space_after_semicolon_in_for_statement = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_around_binary_operators 
+csharp_space_around_binary_operators = before_and_after
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_around_declaration_statements
+csharp_space_around_declaration_statements = do_not_ignore
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_before_colon_in_inheritance_clause
+csharp_space_before_colon_in_inheritance_clause = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_before_comma
+csharp_space_before_comma = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_before_dot
+csharp_space_before_dot = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_before_open_square_brackets
+csharp_space_before_open_square_brackets = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_before_semicolon_in_for_statement
+csharp_space_before_semicolon_in_for_statement = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_empty_square_brackets
+csharp_space_between_empty_square_brackets = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_method_call_empty_parameter_list_parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_method_call_name_and_opening_parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_method_call_parameter_list_parentheses
+csharp_space_between_method_call_parameter_list_parentheses = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_method_declaration_empty_parameter_list_parentheses
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_method_declaration_name_and_open_parenthesis
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_method_declaration_parameter_list_parentheses
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_parentheses
+csharp_space_between_parentheses = none
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_between_square_brackets
+csharp_space_between_square_brackets = false
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_conditional_delegate_call
+# csharp_style_conditional_delegate_call = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_expression_bodied_accessors
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_expression_bodied_constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_expression_bodied_indexers
+csharp_style_expression_bodied_indexers = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_expression_bodied_methods
+csharp_style_expression_bodied_methods = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_expression_bodied_operators
+csharp_style_expression_bodied_operators =true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_expression_bodied_properties
+csharp_style_expression_bodied_properties = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_inlined_variable_declaration
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_pattern_matching_over_as_with_null_check
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_pattern_matching_over_is_with_cast_check
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_throw_expression
+csharp_style_throw_expression = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_var_elsewhere
+# csharp_style_var_elsewhere = false:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_var_for_built_in_types
+# csharp_style_var_for_built_in_types = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_style_var_when_type_is_apparent
+# csharp_style_var_when_type_is_apparent = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_sort_system_directives_first
+dotnet_sort_system_directives_first = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_coalesce_expression
+dotnet_style_coalesce_expression = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_collection_initializer
+dotnet_style_collection_initializer = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_explicit_tuple_names
+dotnet_style_explicit_tuple_names = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_null_propagation
+dotnet_style_null_propagation = true:suggestion
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_object_initializer
+dotnet_style_object_initializer = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_predefined_type_for_locals_parameters_members
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_predefined_type_for_member_access
+dotnet_style_predefined_type_for_member_access = true:error
+
+# Maybe let's not enforce 'this.' for stuff? https://stackoverflow.com/a/2207153
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_qualification_for_event
+# dotnet_style_qualification_for_event = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_qualification_for_field
+# dotnet_style_qualification_for_field = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_qualification_for_method
+# dotnet_style_qualification_for_method = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_style_qualification_for_property
+# dotnet_style_qualification_for_property = true:error
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#insert_final_newline
+insert_final_newline = true
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#tab_width
+tab_width = 4
+
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_naming_
+
+# Rule: non-public static fields must have prefix 's_' and be camel case.
+# define a class of symbols that we name 'non_public_static_field_symbol':
+dotnet_naming_symbols.non_public_static_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.non_public_static_field_symbol.applicable_accessibilities = private,internal,protected,protected_internal
+dotnet_naming_symbols.non_public_static_field_symbol.required_modifiers = static
+
+# # define a style called 'non_public_static_field_style' that enforces camel casing and prefix 's_':
+dotnet_naming_style.non_public_static_field_style.capitalization = camel_case
+dotnet_naming_style.non_public_static_field_style.required_prefix = s_
+
+# # define a naming rule called 'non_public_static_fields_must_be_prefixed_with_s_' that marries up the above symbol definition with the above style definition:
+dotnet_naming_rule.non_public_static_fields_must_be_prefixed_with_s_.severity = suggestion
+dotnet_naming_rule.non_public_static_fields_must_be_prefixed_with_s_.symbols = non_public_static_field_symbol
+dotnet_naming_rule.non_public_static_fields_must_be_prefixed_with_s_.style = non_public_static_field_style
+
+dotnet_naming_symbols.private_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.private_field_symbol.applicable_accessibilities = private,internal
+dotnet_naming_style.private_field_style.capitalization = camel_case
+dotnet_naming_style.private_field_style.required_prefix = _
+dotnet_naming_rule.private_fields_are_camel_case.severity = error
+dotnet_naming_rule.private_fields_are_camel_case.symbols = private_field_symbol
+dotnet_naming_rule.private_fields_are_camel_case.style = private_field_style
+
+dotnet_naming_symbols.public_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.public_field_symbol.applicable_accessibilities = public
+dotnet_naming_style.public_field_style.capitalization = pascal_case
+dotnet_naming_rule.non_private_fields_are_pascal_case.severity = error
+dotnet_naming_rule.non_private_fields_are_pascal_case.symbols = public_field_symbol
+dotnet_naming_rule.non_private_fields_are_pascal_case.style = public_field_style
+
+dotnet_naming_symbols.parameter_symbol.applicable_kinds = parameter
+dotnet_naming_style.parameter_style.capitalization = camel_case
+dotnet_naming_rule.parameters_are_camel_case.severity = error
+dotnet_naming_rule.parameters_are_camel_case.symbols = parameter_symbol
+dotnet_naming_rule.parameters_are_camel_case.style = parameter_style
+
+dotnet_naming_symbols.non_interface_type_symbol.applicable_kinds = class,struct,enum,delegate
+dotnet_naming_style.non_interface_type_style.capitalization = pascal_case
+dotnet_naming_rule.non_interface_types_are_pascal_case.severity = error
+dotnet_naming_rule.non_interface_types_are_pascal_case.symbols = non_interface_type_symbol
+dotnet_naming_rule.non_interface_types_are_pascal_case.style = non_interface_type_style
+
+dotnet_naming_symbols.interface_type_symbol.applicable_kinds = interface
+dotnet_naming_style.interface_type_style.capitalization = pascal_case
+dotnet_naming_style.interface_type_style.required_prefix = I
+dotnet_naming_rule.interface_types_must_be_prefixed_with_I.severity = error
+dotnet_naming_rule.interface_types_must_be_prefixed_with_I.symbols = interface_type_symbol
+dotnet_naming_rule.interface_types_must_be_prefixed_with_I.style = interface_type_style
+
+dotnet_naming_symbols.member_symbol.applicable_kinds = method,property,event
+dotnet_naming_style.member_style.capitalization = pascal_case
+dotnet_naming_rule.members_are_pascal_case.severity = error
+dotnet_naming_rule.members_are_pascal_case.symbols = member_symbol
+dotnet_naming_rule.members_are_pascal_case.style = member_style

--- a/CrystalDocumenter.csproj
+++ b/CrystalDocumenter.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DocObjects/AssemblyDocumentation.cs
+++ b/DocObjects/AssemblyDocumentation.cs
@@ -24,11 +24,11 @@ namespace CrystalDocumenter.DocObjects;
 public class AssemblyDocumentation
 {
   public readonly Assembly Origin;
-  public static readonly MarkdownPipeline pipeline;
+  public static readonly MarkdownPipeline Pipeline;
 
   static AssemblyDocumentation()
   {
-    pipeline = new MarkdownPipelineBuilder()
+    Pipeline = new MarkdownPipelineBuilder()
     .UseAdvancedExtensions()
     .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
     .Build();
@@ -152,7 +152,7 @@ public class AssemblyDocumentation
 
       doc.Value.Save(data);
       data.Append(Utils.DefaultFooter);
-      Markdown.ToHtml(data.ToString(), writer, pipeline: pipeline);
+      Markdown.ToHtml(data.ToString(), writer, pipeline: Pipeline);
 
       //Only write top level classes to the index
       if (doc.Value.NestedIn is null)
@@ -162,7 +162,7 @@ public class AssemblyDocumentation
     }
 
     index.Append(Utils.DefaultFooter);
-    Markdown.ToHtml(index.ToString(), indexFile, pipeline: pipeline);
+    Markdown.ToHtml(index.ToString(), indexFile, pipeline: Pipeline);
   }
 
   public void BuildXMLDoc(string output = "Documentation")

--- a/DocObjects/MethodDocumentation.cs
+++ b/DocObjects/MethodDocumentation.cs
@@ -36,14 +36,20 @@ public class MethodDocumentation
   public List<ParameterDocumentation> Parameters = [];
 
   [JsonConstructor]
-  public MethodDocumentation(string Accessibility, string MethodName, string MethodSummary, bool IsStatic, string ReturnType, List<ParameterDocumentation> Parameters)
+  public MethodDocumentation(
+    string accessibility,
+    string methodName,
+    string methodSummary,
+    bool isStatic,
+    string returnType,
+    List<ParameterDocumentation> parameters)
   {
-    this.Accessibility = Accessibility;
-    this.MethodName = MethodName;
-    this.MethodSummary = MethodSummary;
-    this.IsStatic = IsStatic;
-    this.ReturnType = ReturnType;
-    this.Parameters = Parameters;
+    Accessibility = accessibility;
+    MethodName = methodName;
+    MethodSummary = methodSummary;
+    IsStatic = isStatic;
+    ReturnType = returnType;
+    Parameters = parameters;
   }
 
   public MethodDocumentation(MethodInfo method)

--- a/DocObjects/ParameterDocumentation.cs
+++ b/DocObjects/ParameterDocumentation.cs
@@ -24,11 +24,14 @@ public class ParameterDocumentation
   public string ParameterSummary;
 
   [JsonConstructor]
-  public ParameterDocumentation(string ParameterName, string ParameterType, string ParameterSummary)
+  public ParameterDocumentation(
+    string parameterName,
+    string parameterType,
+    string parameterSummary)
   {
-    this.ParameterName = ParameterName;
-    this.ParameterType = ParameterType;
-    this.ParameterSummary = ParameterSummary;
+    ParameterName = parameterName;
+    ParameterType = parameterType;
+    ParameterSummary = parameterSummary;
   }
 
   public ParameterDocumentation(ParameterInfo param)

--- a/DocObjects/StrongType.cs
+++ b/DocObjects/StrongType.cs
@@ -12,11 +12,11 @@ using System.Text.Json.Serialization;
 namespace CrystalDocumenter.DocObjects;
 
 [method: JsonConstructor]
-public class StrongType(string Name, string FullName)
+public class StrongType(string name, string fullName)
 {
   [JsonInclude]
-  public string Name = Name;
+  public string Name = name;
 
   [JsonInclude]
-  public string FullName = FullName;
+  public string FullName = fullName;
 }

--- a/DocObjects/TypeDocumentation.cs
+++ b/DocObjects/TypeDocumentation.cs
@@ -35,7 +35,7 @@ public class TypeDocumentation
   public string FullName;
 
   [JsonInclude]
-  public string Namespace = string.Empty;
+  public string TypeNamespace = string.Empty;
 
   [JsonInclude]
   public string TypeSummary = string.Empty;
@@ -67,7 +67,7 @@ public class TypeDocumentation
     string name,
     string fullName,
     string infoHash,
-    string Namespace,
+    string typeNamespace,
     string typeSummary,
     List<MethodDocumentation> methodSignatures,
     List<PropertyDocumentation> properties,
@@ -78,7 +78,7 @@ public class TypeDocumentation
     Parent = parent;
     NestedIn = nestedIn;
     Name = name;
-    this.Namespace = Namespace;
+    TypeNamespace = typeNamespace;
     FullName = fullName;
     InfoHash = infoHash;
     TypeSummary = typeSummary;
@@ -93,7 +93,7 @@ public class TypeDocumentation
   {
     Origin = origin;
     Name = thisType.Name;
-    Namespace = thisType.Namespace ?? string.Empty;
+    TypeNamespace = thisType.Namespace ?? string.Empty;
     FullName = GetFullyQualifiedName(thisType);
     InfoHash = Utils.HashType(thisType);
     DescribedType = thisType;
@@ -177,7 +177,7 @@ public class TypeDocumentation
     data.AppendLine($"- [Methods](#methods)");
 
     data.AppendLine("## Member Info");
-    data.AppendLine($"- **Namespace**: {Namespace}");
+    data.AppendLine($"- **Namespace**: {TypeNamespace}");
     data.AppendLine($"- **FullName**: {FullName}");
     data.AppendLine($"- **Summary**: {TypeSummary}");
 


### PR DESCRIPTION
# Pull Request Description

The CONTRIBUTING.md file has guidelines for code style, but currently there is no system to enforce that style in an IDE. This PR implements that with `.editorconfig`, and setting `<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>` in the csproj to help catch those style issues during build by treating them as build errors. Unfortunately though the [dotnet_naming_*](<https://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#dotnet_naming_>) rules won't cause the build to fail.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
  - As of right now, the rule `Underscore Prefix: Optionally for private fields within a class.` is fully enforced instead of being optional. This is because this rule wasn't violated in the source code so might as well fully enforce it.

> [!NOTE]  
> My changes introduce naming rule violations to the existing code:
> - Parameters which aren't camelCase.

## Checklist

- [x] My code follows the style guidelines of this project
  - Technically, this enforces style more than the guidelines, though in a way that the enforced style mostly applies to existing code.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules where applicable
- [x] I affirm that I am submitting this PR and all contained changes and code on behalf of only myself and not any legal entity in accordance with this project's submission guidelines
- [x] I affirm that I have the right to contribute all contained files and agree that they will be licensed under the project's terms as stated in the LICENSE file.

## Additional Notes

Run `dotnet format CrystalDocumenter.sln -v d` (aka `--verbosity detailed`) to see all code style violations.

Feel free to just modify the `.editorconfig` file to better fit this project's code style. This can work as a template.
I have set almost everything as error severity, they can be changed to warning, suggestion or none. See the links for more information about each setting.